### PR TITLE
Refactor: Replace "Conflictura" with "Vermucito" and update URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "conflictura",
+    "name": "vermucito",
     "version": "3.2.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "conflictura",
+            "name": "vermucito",
             "version": "3.2.7",
             "license": "CC0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "conflictura",
-    "preductname": "Conflictura Launcher",
+    "name": "vermucito",
+    "preductname": "Vermucito Launcher",
     "version": "3.2.7",
-    "description": "Conflictura modded server launcher",
+    "description": "Vermucito modded server launcher",
     "main": "src/app.js",
     "author": "Riptiaz/Boulldogo/Vexato/Luuxis",
     "env": "azuriom",
-    "settings": "https://conflictura.eu",
+    "settings": "https://vermucito.world",
     "scripts": {
         "start": "cross-env-shell NODE_ENV=dev electron .",
         "build": "node build.js --obf=true --build=platform",
         "dev": "cross-env-shell DEV_TOOL=open nodemon --exec npm start",
-        "icon": "node build.js --icon=https://raw.githubusercontent.com/CentralCorp/CentralCorp-Launcher/master/src/assets/images/icon.png"
+        "icon": "node build.js --icon=https://raw.githubusercontent.com/faqperez/Vermu-Launcher/master/src/assets/images/icon.png"
 
     },
     "license": "CC0",
@@ -37,6 +37,6 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/Riptiaz/CentralCorp-Launcher.git"
+        "url": "git+https://github.com/faqperez/Vermu-Launcher.git"
     }
 }

--- a/src/assets/translations/de.json
+++ b/src/assets/translations/de.json
@@ -1,6 +1,6 @@
 {
-    "welcome_message": "Willkommen beim CentralCorp Launcher",
-    "developed_by": "Entwickelt von CentralCorp",
+    "welcome_message": "Willkommen beim Vermucito Launcher",
+    "developed_by": "Entwickelt von Vermucito",
     "checking_updates": "Suche nach Updates",
     "loading": "Laden...",
     "play": "Spielen",

--- a/src/assets/translations/en.json
+++ b/src/assets/translations/en.json
@@ -1,6 +1,6 @@
 {
-    "welcome_message": "Welcome to the CentralCorp Launcher",
-    "developed_by": "Developed by CentralCorp",
+    "welcome_message": "Welcome to the Vermucito Launcher",
+    "developed_by": "Developed by Vermucito",
     "checking_updates": "Checking for updates",
     "loading": "Loading...",
     "play": "Play",

--- a/src/assets/translations/es.json
+++ b/src/assets/translations/es.json
@@ -1,6 +1,6 @@
 {
-    "welcome_message": "Bienvenido al lanzador de CentralCorp",
-    "developed_by": "Desarrollado por CentralCorp",
+    "welcome_message": "Bienvenido al lanzador de Vermucito",
+    "developed_by": "Desarrollado por Vermucito",
     "checking_updates": "Buscando actualizaciones",
     "loading": "Cargando...",
     "play": "Jugar",

--- a/src/assets/translations/fr.json
+++ b/src/assets/translations/fr.json
@@ -1,6 +1,6 @@
 {
-    "welcome_message": "Bienvenue dans le launcher CentralCorp",
-    "developed_by": "Développé par CentralCorp",
+    "welcome_message": "Bienvenue dans le launcher Vermucito",
+    "developed_by": "Développé par Vermucito",
     "checking_updates": "Recherche de mise à jour",
     "loading": "Chargement...",
     "play": "Jouer",

--- a/src/assets/translations/ru.json
+++ b/src/assets/translations/ru.json
@@ -1,6 +1,6 @@
 {
-    "welcome_message": "Добро пожаловать в лаунчер CentralCorp",
-    "developed_by": "Разработано CentralCorp",
+    "welcome_message": "Добро пожаловать в лаунчер Vermucito",
+    "developed_by": "Разработано Vermucito",
     "checking_updates": "Проверка обновлений",
     "loading": "Загрузка...",
     "play": "Играть",


### PR DESCRIPTION
I've replaced all instances of "Conflictura" and "conflictura" with "Vermucito" and "vermucito" respectively. Additionally, the specific URL "https://conflictura.eu" was changed to "https://vermucito.world".

Affected files:
- package.json:
    - "name" changed from "conflictura" to "vermucito".
    - "preductname" (sic) updated from "Conflictura Launcher" to "Vermucito Launcher".
    - "description" updated.
    - "settings" URL changed to "https://vermucito.world".
- package-lock.json:
    - Main package "name" changed to "vermucito".